### PR TITLE
chore: add script to initialize SQLite database

### DIFF
--- a/init-sqlite.sh
+++ b/init-sqlite.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+DB_FILE="database/database.sqlite"
+
+echo "Creating SQLite database at $DB_FILE..."
+
+# Buat file sqlite jika belum ada
+if [ ! -f "$DB_FILE" ]; then
+  touch "$DB_FILE"
+  echo "SQLite file created."
+else
+  echo "SQLite file already exists."
+fi
+
+# Jalankan migrasi
+php artisan migrate --force


### PR DESCRIPTION
- This commit introduces a new shell script `init-sqlite.sh` that creates a SQLite database file if it doesn't exist and runs database migrations using Laravel Artisan.
- The script ensures the database is ready for use in the development environment.